### PR TITLE
Attempt to optimize Upserts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 clap = { version = "4.5.4", features = ["derive"] }
 csv = "1.3.0"
 futures = "0.3"
-mongodb = "2.8.2"
+mongodb = { version = "2.8.2", default-features = false, features = ["sync"]}
 lazy_static = "1.4.0"
 log = "0.4.21"
 serde = { version = "1.0.197", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Options:
   -d, --mongo-db <MONGO-DB>                  MongoDB database [default: whois]
   -c, --mongo-collection <MONGO-COLLECTION>  MongoDB collection [default: feeds]
   -t, --threads <THREADS>                    Number of threads to use [default: 512]
-  --mongo-user <MONGO-USER>              MongoDB User [default: ]
-  --mongo-password <MONGO-PASSWORD>      MongoDB Password [default: ]
-  --debug                                Enable debug mode
-  --help                                 
+      --mongo-user <MONGO-USER>              MongoDB User [default: ]
+      --mongo-password <MONGO-PASSWORD>      MongoDB Password [default: ]
+      --debug                                Enable debug mode
+      --help                                 
   -V, --version                              Print version
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Options:
   -p, --mongo-port <MONGO-PORT>              MongoDB port [default: 27017]
   -d, --mongo-db <MONGO-DB>                  MongoDB database [default: whois]
   -c, --mongo-collection <MONGO-COLLECTION>  MongoDB collection [default: feeds]
-      --mongo-user <MONGO-USER>              MongoDB User [default: ]
-      --mongo-password <MONGO-PASSWORD>      MongoDB Password [default: ]
-      --debug                                Enable debug mode
-      --help                                 
+  -t, --threads <THREADS>                    Number of threads to use [default: 512]
+  --mongo-user <MONGO-USER>              MongoDB User [default: ]
+  --mongo-password <MONGO-PASSWORD>      MongoDB Password [default: ]
+  --debug                                Enable debug mode
+  --help                                 
   -V, --version                              Print version
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,10 @@ pub struct CliOpts {
     /// Enable debug mode.
     #[arg(long, value_name = "DEBUG", default_value_t = false)]
     pub debug: bool,
+    
+    /// Number of threads to use.
+    #[arg(short = 't', long, value_name = "THREADS", default_value_t = 512)]
+    pub threads: usize,
 
     #[clap(long, action = clap::ArgAction::HelpLong)]
     help: Option<bool>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,10 +139,8 @@ pub async fn read_directory(source_folder: &str) -> Result<()> {
                 // let records = records.iter().map(|r| r.into()).collect::<Vec<_>>();
                 info!("Found {} records in the file {}", records.len(), file_path);
                 // Chunk the records into 5000 records and save them
-                let records = records[0..100000].to_vec();
-                
                 let chunked_records = records
-                    .chunks(1000)
+                    .chunks(5000)
                     .map(|x| x.to_vec())
                     .collect::<Vec<_>>();
                 let mut handles = Vec::new();


### PR DESCRIPTION
This PR attempts to optimize upserts to the database through modifying the `tokio` runtime to  accept a custom number of blocking threads. The thread count can be provided as a cli arg.

This results in an improved perfomance of up to `64%`.

Initially saving 100k records took up to `738 secs` on an `Intel® Xeon(R) CPU E5-2673 v3 @ 2.40GHz × 24` processor. After the modifications we get that down to `450 secs`.